### PR TITLE
[1.x] Independent Recovery Codes

### DIFF
--- a/src/Models/TwoFactorAuthentication.php
+++ b/src/Models/TwoFactorAuthentication.php
@@ -116,14 +116,16 @@ class TwoFactorAuthentication extends Model implements TwoFactorTotp
      */
     public function flushAuth(): static
     {
-        $this->recovery_codes_generated_at = null;
+        if (config('two-factor.recovery.enabled')) {
+            $this->recovery_codes = null;
+            $this->recovery_codes_generated_at = null;
+        }
         $this->safe_devices = null;
         $this->enabled_at = null;
 
         $this->attributes = array_merge($this->attributes, config('two-factor.totp'));
 
         $this->shared_secret = static::generateRandomSecret();
-        $this->recovery_codes = null;
 
         return $this;
     }

--- a/tests/Eloquent/TwoFactorAuthenticationTest.php
+++ b/tests/Eloquent/TwoFactorAuthenticationTest.php
@@ -79,9 +79,11 @@ class TwoFactorAuthenticationTest extends TestCase
         static::assertNotNull($tfa->seconds);
         static::assertNotNull($tfa->window);
         static::assertNotNull($tfa->algorithm);
+        static::assertNotNull($tfa->recovery_codes);
         static::assertNotNull($tfa->recovery_codes_generated_at);
         static::assertNotNull($tfa->safe_devices);
 
+        $this->app->make('config')->set('two-factor.recovery.enabled', false);
         $tfa->flushAuth()->save();
 
         static::assertNotEquals($old, $tfa->shared_secret);
@@ -92,8 +94,15 @@ class TwoFactorAuthenticationTest extends TestCase
         static::assertEquals(config('two-factor.totp.seconds'), $tfa->seconds);
         static::assertEquals(config('two-factor.totp.window'), $tfa->window);
         static::assertEquals(config('two-factor.totp.algorithm'), $tfa->algorithm);
-        static::assertNull($tfa->recovery_codes_generated_at);
+        static::assertNotNull($tfa->recovery_codes);
+        static::assertNotNull($tfa->recovery_codes_generated_at);
         static::assertNull($tfa->safe_devices);
+
+        $this->app->make('config')->set('two-factor.recovery.enabled', true);
+        $tfa->flushAuth()->save();
+
+        static::assertNull($tfa->recovery_codes);
+        static::assertNull($tfa->recovery_codes_generated_at);
     }
 
     public function test_generates_random_secret(): void


### PR DESCRIPTION
# Description

The recovery code logic is great! If you use multiple two-factor options for the application, you may want to reuse the recovery code logic independently of the TOTP method.

This PR simply changes the logic so that recovery codes are not deleted when disabled. This allows the developer to use the recovery code system independently and make sure recovery codes are not generated or deleted when enabling or disabling TOTP.