### PR TITLE
[1.x] Fix: Use config model for `twoFactorAuth` relation

### DIFF
--- a/src/TwoFactorAuthentication.php
+++ b/src/TwoFactorAuthentication.php
@@ -36,7 +36,7 @@ trait TwoFactorAuthentication
      */
     public function twoFactorAuth(): MorphOne
     {
-        return $this->morphOne(Models\TwoFactorAuthentication::class, 'authenticatable')
+        return $this->morphOne(config('two-factor.model'), 'authenticatable')
             ->withDefault(static function (Models\TwoFactorAuthentication $model): Models\TwoFactorAuthentication {
                 return $model->fill(config('two-factor.totp'));
             });


### PR DESCRIPTION
<!--

Thanks for contributing to this package! We only accept PR to the latest stable version.

If you're pushing a Feature:
- Title it: "[X.x] This new feature"
- Describe what the new feature enables
- Show a small code snippet of the new feature
- Ensure it doesn't break any feature.

If you're pushing a Fix:
- Title it: "[X.x] FIX: The bug name"
- Describe how it fixes in a few words.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP and Laravel. 
Ensure your tests pass or your PR may be taken down.

If you're a Patreon supporter, this PR will have priority.
Not a Patreon supporter? Become one at https://patreon.com/packagesforlaravel
-->

# Description
The `twoFactorAuth` relation always returns an instance of the base [TwoFactorAuthentication](https://github.com/Laragear/TwoFactor/blob/7f24388f96c912b36a2c677e3a9f75b294253883/src/Models/TwoFactorAuthentication.php) class, regardless of the config `model` value.

Updated the relation to return an instance of the config model.
