### PR TITLE
[1.x] Allow overriding the default table name.

### DIFF
--- a/config/two-factor.php
+++ b/config/two-factor.php
@@ -3,6 +3,19 @@
 return [
     /*
     |--------------------------------------------------------------------------
+    | Database table name
+    |--------------------------------------------------------------------------
+    |
+    | If you have modified the default table name during your migration, then
+    | set this to your actual table name. Otherwise, leave this as null to use
+    | the default table name.
+    |
+    */
+
+    'table_name' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Cache Store
     |--------------------------------------------------------------------------
     |

--- a/src/Models/TwoFactorAuthentication.php
+++ b/src/Models/TwoFactorAuthentication.php
@@ -70,6 +70,16 @@ class TwoFactorAuthentication extends Model implements TwoFactorTotp
     protected $fillable = ['digits', 'seconds', 'window', 'algorithm'];
 
     /**
+     * Get the table associated with the model.
+     *
+     * @return string
+     */
+    public function getTable()
+    {
+        return config('two-factor.table_name') ?? parent::getTable();
+    }
+
+    /**
      * The model that uses Two-Factor Authentication.
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo


### PR DESCRIPTION
This feature users to override the default table created during a migration by adding a configuration entry for the new table name.

Added config entry to allow setting a value, without this entry, or null drops back to the existing behavior.

```
'table_name' => null,
```

Added fallback for table name in model.
```
public function getTable()
{
    return config('two-factor.table_name') ?? parent::getTable();
}
```
