### PR TITLE
[2.x] FIX: Redirection route in ConfirmTwoFactorCode middleware.

### DIFF
--- a/src/Http/Middleware/ConfirmTwoFactorCode.php
+++ b/src/Http/Middleware/ConfirmTwoFactorCode.php
@@ -42,7 +42,7 @@ class ConfirmTwoFactorCode
     /**
      * Determine the route to redirect the user.
      */
-    protected function getRedirectionRoute($route)
+    protected function getRedirectionRoute(string $route): string
     {
         // If the developer is forcing this middleware to always run,
         // then return redirection route "2fa.confirm" as default.

--- a/src/Http/Middleware/ConfirmTwoFactorCode.php
+++ b/src/Http/Middleware/ConfirmTwoFactorCode.php
@@ -32,9 +32,25 @@ class ConfirmTwoFactorCode
             return $next($request);
         }
 
+        $route = $this->getRedirectionRoute($route);
+
         return $request->expectsJson()
             ? response()->json(['message' => trans('two-factor::messages.required')], 403)
             : response()->redirectGuest(url()->route($route));
+    }
+
+    /**
+     * Determine the route to redirect the user.
+     */
+    protected function getRedirectionRoute($route)
+    {
+        // If the developer is forcing this middleware to always run,
+        // then return redirection route "2fa.confirm" as default.
+        // Otherwise, return the route as the developer set it.
+        if (in_array(strtolower($route), ['true', 'force'], true)) {
+            return '2fa.confirm';
+        }
+        return $route;
     }
 
     /**

--- a/src/Http/Middleware/ConfirmTwoFactorCode.php
+++ b/src/Http/Middleware/ConfirmTwoFactorCode.php
@@ -50,6 +50,7 @@ class ConfirmTwoFactorCode
         if (in_array(strtolower($route), ['true', 'force'], true)) {
             return '2fa.confirm';
         }
+
         return $route;
     }
 

--- a/tests/Http/Middleware/ConfirmTwoFactorEnabledTest.php
+++ b/tests/Http/Middleware/ConfirmTwoFactorEnabledTest.php
@@ -67,6 +67,22 @@ class ConfirmTwoFactorEnabledTest extends TestCase
     {
         $this->app['router']->get('intended_force', function () {
             return 'ok';
+        })->name('intended')->middleware('web', 'auth', '2fa.confirm:true');
+
+        $this->actingAs($this->user);
+
+        $sessionKey = $this->app->make('config')->get('two-factor.confirm.key').'confirm.expires_at';
+
+        $this->session([$sessionKey => now()->addHour()->getTimestamp()]);
+
+        $this->getJson('intended_force')->assertJson(['message' => trans('two-factor::messages.required')]);
+        $this->get('intended_force')->assertRedirect('confirm');
+    }
+
+    public function test_asks_for_confirmation_if_forced_with_custom_route(): void
+    {
+        $this->app['router']->get('intended_force', function () {
+            return 'ok';
         })->name('intended')->middleware('web', 'auth', '2fa.confirm:2fa.confirm,true');
 
         $this->actingAs($this->user);


### PR DESCRIPTION
Adjusted Redirection Route Handling in Middleware.

# Description

This fix refines the handling of the first parameter, "$route", in the ConfirmTwoFactorCode Middleware. It ensures the middleware functions correctly when the developer is forcing the middleware to run, without necessarily altering the default route.

# Code samples
How to make it work without the fix
```php
Route::get('/example', [ExampleController::class, 'create'])->middleware('2fa.confirm:2fa.confirm,force');
```
With the fix
```php
Route::get('/example', [ExampleController::class, 'create'])->middleware('2fa.confirm:force');
```
