### PR TITLE
[2.x] Expose attemptWhen method

### DIFF
--- a/src/Facades/Auth2FA.php
+++ b/src/Facades/Auth2FA.php
@@ -7,6 +7,7 @@ use Laragear\TwoFactor\TwoFactorLoginHelper;
 
 /**
  * @method static bool attempt(array $credentials = [], mixed $remember = false)
+ * @method static bool attemptWhen(array $credentials = [], array|callable|null  $callbacks = null, mixed $remember = false)
  * @method static \Laragear\TwoFactor\TwoFactorLoginHelper view(string $view)
  * @method static \Laragear\TwoFactor\TwoFactorLoginHelper message(string $message)
  * @method static \Laragear\TwoFactor\TwoFactorLoginHelper input(string $input)


### PR DESCRIPTION
# Description

This feature branch adds and exposes the `attemptWhen` method to/on the `TwoFactorLoginHelper` and `Auth2FA`. This allows projects that need to pass their own callbacks for pre-login checks to integrate with this package.

This will not break backward compatibility since it merely adds a new method.

# Code samples

This PR simply adds a new method matching the signature of the `SessionGuard`'s method:

```php
    public function attemptWhen(array $credentials = [], $callbacks = null, $remember = false): bool
    {
        // Code same as old `attempt` method.
        // Only change: merge $callbacks and the TwoFactor callback
        // ...

        return $guard->attemptWhen(
            $credentials, array_merge(Arr::wrap($callbacks), [TwoFactor::hasCodeOrFails($this->input, $this->message)]), $remember
        );

        // ...
    }
```

And changes the current `attempt` method to call this new method passing `null` as `$callbacks`:

```php
    public function attempt(array $credentials = [], $remember = false): bool
    {
        return $this->attemptWhen($credentials, null, $remember);
    }
``` 

This approach seems cleaner than simply duplicating the code (which is actually what the `SessionGuard` does).