### PR TITLE
[2.0] FIX: Exception "Serialization of 'Closure' is not allowed" in event Listeners.

### DIFF
--- a/src/Events/TwoFactorDisabled.php
+++ b/src/Events/TwoFactorDisabled.php
@@ -2,10 +2,13 @@
 
 namespace Laragear\TwoFactor\Events;
 
+use Illuminate\Queue\SerializesModels;
 use Laragear\TwoFactor\Contracts\TwoFactorAuthenticatable;
 
 class TwoFactorDisabled
 {
+    use SerializesModels;
+
     /**
      * Create a new event instance.
      */

--- a/src/Events/TwoFactorEnabled.php
+++ b/src/Events/TwoFactorEnabled.php
@@ -2,10 +2,13 @@
 
 namespace Laragear\TwoFactor\Events;
 
+use Illuminate\Queue\SerializesModels;
 use Laragear\TwoFactor\Contracts\TwoFactorAuthenticatable;
 
 class TwoFactorEnabled
 {
+    use SerializesModels;
+
     /**
      * Create a new event instance.
      */

--- a/src/Events/TwoFactorRecoveryCodesDepleted.php
+++ b/src/Events/TwoFactorRecoveryCodesDepleted.php
@@ -2,10 +2,13 @@
 
 namespace Laragear\TwoFactor\Events;
 
+use Illuminate\Queue\SerializesModels;
 use Laragear\TwoFactor\Contracts\TwoFactorAuthenticatable;
 
 class TwoFactorRecoveryCodesDepleted
 {
+    use SerializesModels;
+
     /**
      * Create a new event instance.
      */

--- a/src/Events/TwoFactorRecoveryCodesGenerated.php
+++ b/src/Events/TwoFactorRecoveryCodesGenerated.php
@@ -2,10 +2,13 @@
 
 namespace Laragear\TwoFactor\Events;
 
+use Illuminate\Queue\SerializesModels;
 use Laragear\TwoFactor\Contracts\TwoFactorAuthenticatable;
 
 class TwoFactorRecoveryCodesGenerated
 {
+    use SerializesModels;
+
     /**
      * Create a new event instance.
      */


### PR DESCRIPTION
# Description

This Pull Request fixes issue #82.

It adds the `SerializesModels` trait to all events in the package.

The code is tested in a local environment and all the tests pass.