### PR TITLE
Fix php8.4 deprecated notices

### DIFF
--- a/src/Contracts/TwoFactorTotp.php
+++ b/src/Contracts/TwoFactorTotp.php
@@ -11,7 +11,7 @@ interface TwoFactorTotp extends Renderable, Stringable
     /**
      * Validates a given code, optionally for a given timestamp and future window.
      */
-    public function validateCode(string $code, DateTimeInterface|int|string $at = 'now', int $window = null): bool;
+    public function validateCode(string $code, DateTimeInterface|int|string $at = 'now', ?int $window = null): bool;
 
     /**
      * Creates a Code for a given timestamp, optionally by a given period offset.

--- a/src/Models/Concerns/HandlesCodes.php
+++ b/src/Models/Concerns/HandlesCodes.php
@@ -42,7 +42,7 @@ trait HandlesCodes
     /**
      * Returns the Cache Store to use.
      */
-    protected function useCacheStore(string $store = null): Repository
+    protected function useCacheStore(?string $store = null): Repository
     {
         return cache()->store($store);
     }
@@ -50,7 +50,7 @@ trait HandlesCodes
     /**
      * Validates a given code, optionally for a given timestamp and future window.
      */
-    public function validateCode(string $code, DateTimeInterface|int|string $at = 'now', int $window = null): bool
+    public function validateCode(string $code, DateTimeInterface|int|string $at = 'now', ?int $window = null): bool
     {
         if ($this->codeHasBeenUsed($code)) {
             return false;

--- a/src/Models/Concerns/HandlesRecoveryCodes.php
+++ b/src/Models/Concerns/HandlesRecoveryCodes.php
@@ -61,7 +61,7 @@ trait HandlesRecoveryCodes
      *
      * @param  (callable(int $length, int $iteration, int $amount): \Illuminate\Support\Collection<int, int|string>)|null  $callback
      */
-    public static function generateRecoveryCodesUsing(callable $callback = null): void
+    public static function generateRecoveryCodesUsing(?callable $callback = null): void
     {
         static::$generator = $callback;
     }

--- a/src/Models/Concerns/HandlesSafeDevices.php
+++ b/src/Models/Concerns/HandlesSafeDevices.php
@@ -10,7 +10,7 @@ trait HandlesSafeDevices
     /**
      * Returns the timestamp of the Safe Device.
      */
-    public function getSafeDeviceTimestamp(string $token = null): ?Carbon
+    public function getSafeDeviceTimestamp(?string $token = null): ?Carbon
     {
         if ($token && $device = $this->safe_devices?->firstWhere('2fa_remember', $token)) {
             return Carbon::createFromTimestamp($device['added_at']);

--- a/src/TwoFactor.php
+++ b/src/TwoFactor.php
@@ -46,7 +46,7 @@ class TwoFactor
      */
     public static function hasCodeOrFails(
         string $input = '2fa_code',
-        string $message = null,
+        ?string $message = null,
         string $safeDeviceInput = 'safe_device'
     ): Closure {
         return static function ($user) use ($input, $message, $safeDeviceInput): bool {


### PR DESCRIPTION
Fixes

```
PHP Deprecated:  Laragear\TwoFactor\TwoFactor::hasCodeOrFails(): Implicitly marking parameter $message as nullable is deprecated, the explicit nullable type must be used instead in ./src/TwoFactor.php on line 47
PHP Deprecated:  Laragear\TwoFactor\Contracts\TwoFactorTotp::validateCode(): Implicitly marking parameter $window as nullable is deprecated, the explicit nullable type must be used instead in ./src/Contracts/TwoFactorTotp.php on line 14
PHP Deprecated:  Laragear\TwoFactor\Models\Concerns\HandlesSafeDevices::getSafeDeviceTimestamp(): Implicitly marking parameter $token as nullable is deprecated, the explicit nullable type must be used instead in ./src/Models/Concerns/HandlesSafeDevices.php on line 13
PHP Deprecated:  Laragear\TwoFactor\Models\Concerns\HandlesCodes::useCacheStore(): Implicitly marking parameter $store as nullable is deprecated, the explicit nullable type must be used instead in ./src/Models/Concerns/HandlesCodes.php on line 45
PHP Deprecated:  Laragear\TwoFactor\Models\Concerns\HandlesCodes::validateCode(): Implicitly marking parameter $window as nullable is deprecated, the explicit nullable type must be used instead in ./src/Models/Concerns/HandlesCodes.php on line 53
PHP Deprecated:  Laragear\TwoFactor\Models\Concerns\HandlesRecoveryCodes::generateRecoveryCodesUsing(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in ./src/Models/Concerns/HandlesRecoveryCodes.php on line 64
```